### PR TITLE
Add NativeLibraries MSBuild flag, enable more platforms

### DIFF
--- a/BertCppLib/BertCppInterop.cs
+++ b/BertCppLib/BertCppInterop.cs
@@ -27,7 +27,7 @@ namespace BertCppLib
 
 #if WINDOWS
         private const string LibName = $"{nameof(BertCppLib)}/bert";
-#elif LINUX
+#elif LINUX || MACOS
         private const string LibName = $"{nameof(BertCppLib)}/libbert";
 #endif
 

--- a/BertCppLib/BertCppLib.csproj
+++ b/BertCppLib/BertCppLib.csproj
@@ -4,18 +4,17 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Platforms>x64</Platforms>
 		<BaseOutputPath>..</BaseOutputPath>
 		<LangVersion>latest</LangVersion>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-		<DefineConstants Condition="'$(OS)' == 'Windows_NT'">WINDOWS</DefineConstants>
-		<DefineConstants Condition="$([System.String]::new('$(OS)').StartsWith('Unix'))">LINUX</DefineConstants>
+		<DefineConstants Condition="$([MSBuild]::IsOSPlatform('Windows'))">WINDOWS</DefineConstants>
+		<DefineConstants Condition="$([MSBuild]::IsOSPlatform('Linux'))">LINUX</DefineConstants>
+		<DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">MACOS</DefineConstants>
 	</PropertyGroup>
 
-	<Target Name="CMakePrepareForBuild" BeforeTargets="PrepareForBuild;Clean">
+	<Target Name="CMakePrepareForBuild" BeforeTargets="PrepareForBuild;Clean" Condition="'$(NativeLibraries)'!='OFF'">
 		<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
 			<Test>$(VsInstallRoot)</Test>
 			<CMakeBin Condition="Exists('$(Test)')">"$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"</CMakeBin>
@@ -29,7 +28,7 @@
 		</PropertyGroup>
 	</Target>
 
-	<Target Name="CMakeConfigure" BeforeTargets="Build">
+	<Target Name="CMakeConfigure" BeforeTargets="Build" Condition="'$(NativeLibraries)'!='OFF'">
 		<PropertyGroup>
 			<CMakeCompilerFlags Condition="'$(OS)' == 'Windows_NT'">-DCMAKE_CXX_FLAGS="/W0 /EHsc /w" -DCMAKE_C_FLAGS="/W0 /w"</CMakeCompilerFlags>
 			<CMakeCompilerFlags Condition="$([System.String]::new('$(OS)').StartsWith('Unix'))">-DCMAKE_CXX_FLAGS=-w -DCMAKE_C_FLAGS=-w</CMakeCompilerFlags>
@@ -37,11 +36,11 @@
 		<Exec Command='$(CMakeBin) -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=$(Configuration) -S "$(CMakeProject)" -B "$(CMakeProject)" $(CMakeCompilerFlags)' />
 	</Target>
 
-	<Target Name="CMakeBuild" AfterTargets="CMakeConfigure">
+	<Target Name="CMakeBuild" AfterTargets="CMakeConfigure" Condition="'$(NativeLibraries)'!='OFF'">
 		<Exec Command='$(CMakeBin) --build "$(CMakeProject)" -j8 --config $(Configuration)' />
 	</Target>
 
-	<Target Name="CMakeCopyOutput" AfterTargets="CMakeBuild">
+	<Target Name="CMakeCopyOutput" AfterTargets="CMakeBuild" Condition="'$(NativeLibraries)'!='OFF'">
 		<PropertyGroup>
 			<LibraryFileExtension Condition="'$(OS)' == 'Windows_NT'">*.dll</LibraryFileExtension>
 			<LibraryFileExtension Condition="$([System.String]::new('$(OS)').StartsWith('Unix'))">lib*.so</LibraryFileExtension>

--- a/LlamaCppCli/LlamaCppCli.csproj
+++ b/LlamaCppCli/LlamaCppCli.csproj
@@ -5,7 +5,6 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Platforms>x64</Platforms>
 		<BaseOutputPath>..</BaseOutputPath>
 		<LangVersion>latest</LangVersion>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/LlamaCppLib/LlamaCppInterop.cs
+++ b/LlamaCppLib/LlamaCppInterop.cs
@@ -157,7 +157,7 @@ namespace LlamaCppLib
 
 #if WINDOWS
         private const string LibName = $"{nameof(LlamaCppLib)}/llama";
-#elif LINUX
+#elif LINUX || MACOS
         private const string LibName = $"{nameof(LlamaCppLib)}/libllama";
 #endif
 

--- a/LlamaCppLib/LlamaCppLib.csproj
+++ b/LlamaCppLib/LlamaCppLib.csproj
@@ -4,18 +4,17 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Platforms>x64</Platforms>
 		<BaseOutputPath>..</BaseOutputPath>
 		<LangVersion>latest</LangVersion>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-		<DefineConstants Condition="'$(OS)' == 'Windows_NT'">WINDOWS</DefineConstants>
-		<DefineConstants Condition="$([System.String]::new('$(OS)').StartsWith('Unix'))">LINUX</DefineConstants>
+		<DefineConstants Condition="$([MSBuild]::IsOSPlatform('Windows'))">WINDOWS</DefineConstants>
+		<DefineConstants Condition="$([MSBuild]::IsOSPlatform('Linux'))">LINUX</DefineConstants>
+		<DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">MACOS</DefineConstants>
 	</PropertyGroup>
 
-	<Target Name="CMakePrepareForBuild" BeforeTargets="PrepareForBuild;Clean">
+	<Target Name="CMakePrepareForBuild" BeforeTargets="PrepareForBuild;Clean" Condition="'$(NativeLibraries)'!='OFF'">
 		<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
 			<Test>$(VsInstallRoot)</Test>
 			<CMakeBin Condition="Exists('$(Test)')">"$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"</CMakeBin>
@@ -29,7 +28,7 @@
 		</PropertyGroup>
 	</Target>
 
-	<Target Name="CMakeConfigure" BeforeTargets="Build">
+	<Target Name="CMakeConfigure" BeforeTargets="Build" Condition="'$(NativeLibraries)'!='OFF'">
 		<PropertyGroup>
 			<CMakeCompilerFlags Condition="'$(OS)' == 'Windows_NT'">-DCMAKE_CXX_FLAGS="/W0 /EHsc /w /D _MBCS" -DCMAKE_C_FLAGS="/W0 /w"</CMakeCompilerFlags>
 			<CMakeCompilerFlags Condition="$([System.String]::new('$(OS)').StartsWith('Unix'))">-DCMAKE_CXX_FLAGS=-w -DCMAKE_C_FLAGS=-w</CMakeCompilerFlags>
@@ -38,11 +37,11 @@
 		<Exec Command='$(CMakeBin) -DLLAMA_CUBLAS=ON -DLLAMA_CUDA_FORCE_DMMV=ON -DLLAMA_CUDA_DMMV_X=64 -DLLAMA_CUDA_MMV_Y=2 -DLLAMA_ALL_WARNINGS=OFF -DLLAMA_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -S "$(CMakeProject)" -B "$(CMakeProject)" $(CMakeCompilerFlags)' />
 	</Target>
 
-	<Target Name="CMakeBuild" AfterTargets="CMakeConfigure">
+	<Target Name="CMakeBuild" AfterTargets="CMakeConfigure" Condition="'$(NativeLibraries)'!='OFF'">
 		<Exec Command='$(CMakeBin) --build "$(CMakeProject)" -j8 --config $(Configuration)' />
 	</Target>
 
-	<Target Name="CMakeCopyOutput" AfterTargets="CMakeBuild">
+	<Target Name="CMakeCopyOutput" AfterTargets="CMakeBuild" Condition="'$(NativeLibraries)'!='OFF'">
 		<PropertyGroup>
 			<LibraryFileExtension Condition="'$(OS)' == 'Windows_NT'">*.dll</LibraryFileExtension>
 			<LibraryFileExtension Condition="$([System.String]::new('$(OS)').StartsWith('Unix'))">lib*.so</LibraryFileExtension>

--- a/LlamaCppWeb/LlamaCppWeb.csproj
+++ b/LlamaCppWeb/LlamaCppWeb.csproj
@@ -4,7 +4,6 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Platforms>x64</Platforms>
 		<BaseOutputPath>..</BaseOutputPath>
 		<LangVersion>preview</LangVersion>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/clean.cmd
+++ b/clean.cmd
@@ -2,4 +2,5 @@
 git submodule foreach --recursive git clean -fdx
 for /d /r . %%d in (bin) do @if exist "%%d" rmdir /s /q "%%d"
 for /d /r . %%d in (obj) do @if exist "%%d" rmdir /s /q "%%d"
-for /d /r . %%d in (x64) do @if exist "%%d" rmdir /s /q "%%d"
+for /d /r . %%d in (Debug) do @if exist "%%d" rmdir /s /q "%%d"
+for /d /r . %%d in (Release) do @if exist "%%d" rmdir /s /q "%%d"

--- a/clean.sh
+++ b/clean.sh
@@ -2,4 +2,5 @@
 git submodule foreach --recursive git clean -fdx
 find . -type d -name bin -exec rm -rf {} \; 2>/dev/null
 find . -type d -name obj -exec rm -rf {} \; 2>/dev/null
-find . -type d -name x64 -exec rm -rf {} \; 2>/dev/null
+find . -type d -name Debug -exec rm -rf {} \; 2>/dev/null
+find . -type d -name Release -exec rm -rf {} \; 2>/dev/null


### PR DESCRIPTION
Addresses https://github.com/dranger003/llama.cpp-dotnet/issues/9

This updates the csproj and code to allow for:

- Turning off native building of llama.cpp and bert.cpp.
- macOS support

I removed the hardcoded Platform variables for macOS and arm64 Linux and Windows build to work. They should not affect the outputted builds ability to load the native libraries since they are still built for the given platform by cmake (or via the user).